### PR TITLE
Implement controller of CephCluster CR and fix e2e

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
       - run: | 
           export KUBE_VERSION=${{ matrix.config.k8s }} KUBE_RUNTIME=${{ matrix.config.runtime }} KUBE_NETWORK=${{ matrix.config.network }}
           ./hack/cluster.sh up
+          docker login -u=tmaxanc+robot -p=${{ secrets.QUAY_PASSWORD }} quay.io
           make e2e
   cleanup:
     needs: [e2e]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
   e2e:
     needs: [image-build]
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       matrix:
         config:
@@ -63,5 +63,5 @@ jobs:
     needs: [e2e]
     runs-on: self-hosted
     steps:
-      - run: ./hack/prolinux_cluster.sh down
+      - run: ./hack/cluster.sh down
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
   e2e:
     needs: [image-build]
     runs-on: self-hosted
-    timeout-minutes: 15
+    timeout-minutes: 60
     strategy:
       matrix:
         config:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 IMG ?= 192.168.7.16:5000/hypersds-operator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
+# Name prefix to generate the names of all resources. This value must be the same as 'namePrefix' defined in config/default/kustomization.yaml
+NAME_PREFIX ?= hypersds-operator-
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -38,8 +40,10 @@ deploy: manifests
 	kustomize build config/default | kubectl apply -f -
 
 # Clean all deployed resources
-clean:
-	kustomize build config/default | kubectl delete -f -
+clean: uninstall
+	kubectl delete namespace $(NAME_PREFIX)system
+	kubectl delete clusterroles.rbac.authorization.k8s.io $(NAME_PREFIX)manager-role $(NAME_PREFIX)metrics-reader $(NAME_PREFIX)proxy-role
+	kubectl delete clusterrolebinding.rbac.authorization.k8s.io $(NAME_PREFIX)manager-rolebinding $(NAME_PREFIX)proxy-rolebinding
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/Makefile
+++ b/Makefile
@@ -133,27 +133,8 @@ kubebuilder-download:
 	sudo mv /tmp/kubebuilder_2.3.1_linux_amd64 /usr/local/kubebuilder
 	export PATH=$(PATH):/usr/local/kubebuilder/bin
 
-define wait-condition
-	@cond="${1}"; \
-	timeout="${2}"; \
-	interval="${3}"; \
-	n=0; \
-	while [ $${n} -le $${timeout} ] ; do \
-		n=`expr $$n + $$interval`; \
-		echo "Waiting $$n seconds..."; \
-		if [ -z "$${cond}" ]; then echo "Condition is met"; echo $${cond}; true; fi; \
-		sleep $$interval; \
-		kubectl get cephclusters.hypersds.tmax.io; \
-	done; \
-
-	@echo "Timeout"
-	@false
-endef
-
 e2e-deploy: registry docker-build docker-push deploy
-	@echo "deploying cr ..."
-	kubectl apply -f config/samples/hypersds_v1alpha1_cephcluster.yaml
-	$(call wait-condition, kubectl get cephclusters.hypersds.tmax.io | grep Completed, 18000, 30)
+	hack/e2e.sh bootstrap
 
 e2e: e2e-deploy clean
 	@echo "e2e completed"

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ endef
 e2e-deploy: registry docker-build docker-push deploy
 	@echo "deploying cr ..."
 	kubectl apply -f config/samples/hypersds_v1alpha1_cephcluster.yaml
-	$(call wait-condition, kubectl get cephclusters.hypersds.tmax.io | grep Completed, 600, 30)
+	$(call wait-condition, kubectl get cephclusters.hypersds.tmax.io | grep Completed, 18000, 30)
 
 e2e: e2e-deploy clean
 	@echo "e2e completed"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,20 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - hypersds.tmax.io
   resources:
   - cephclusters
@@ -26,3 +40,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/samples/hypersds_v1alpha1_cephcluster.yaml
+++ b/config/samples/hypersds_v1alpha1_cephcluster.yaml
@@ -5,12 +5,13 @@ metadata:
 spec:
   mon:
     count: 1
-  nodes:
-    - name: vagrant
-      accessInfo:
-        ip: 192.168.33.31
-        userId: tmax
-        password: "ck@3434"
-        hostName: vagrant
+  osd:
+    - hostName: vagrant
       devices:
         - /dev/sdb
+  nodes:
+    - ip: 192.168.33.11
+      # userId SHOULD BE ROOT
+      userId: root
+      password: "ck@3434"
+      hostName: vagrant

--- a/controllers/access_configmap.go
+++ b/controllers/access_configmap.go
@@ -1,0 +1,87 @@
+package controllers
+
+import (
+	"context"
+	goerrors "errors"
+	"github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// AccessConfigMapName indicates the name of the configmap that contains ceph cluster access information
+const AccessConfigMapName = "ceph-conf"
+
+func (r *CephClusterReconciler) syncAccessConfig() error {
+	// NotFound error will occur when the access configmap is not created
+	// No error will occur when the access configmap is already created
+	if _, err := r.getConfigMap(AccessConfigMapName); err == nil {
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+
+	klog.Infof("syncAccessConfig: creating access config map %s", AccessConfigMapName)
+	if err := r.updateStateWithReadyToUse(v1alpha1.CephClusterStateCreating, metav1.ConditionFalse, "CephClusterIsCreating", "CephCluster is creating"); err != nil {
+		return err
+	}
+
+	cm, err := r.newAccessConfigMap()
+	if err != nil {
+		return err
+	}
+	if err := r.Client.Create(context.TODO(), cm); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *CephClusterReconciler) newAccessConfigMap() (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        AccessConfigMapName,
+			Namespace:   r.Cluster.Namespace,
+			Annotations: map[string]string{"updated": "no"},
+		},
+		Data: map[string]string{},
+	}
+
+	if err := controllerutil.SetControllerReference(r.Cluster, cm, r.Scheme); err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+func (r *CephClusterReconciler) isAccessConfigMapUpdated() (updated, found bool, err error) {
+	cm, err := r.getConfigMap(AccessConfigMapName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+
+	u, found := cm.Annotations["updated"]
+	if !found {
+		return false, true, goerrors.New("invalid configmap annotation: Must need 'updated'")
+	}
+	return u == "yes", true, nil
+}
+
+func (r *CephClusterReconciler) updateAccessConfigMapAnnotation(updated bool) error {
+	cm, err := r.getConfigMap(AccessConfigMapName)
+	if err != nil {
+		return err
+	}
+	if cm.Annotations == nil {
+		cm.Annotations = map[string]string{}
+	}
+	if updated {
+		cm.Annotations["updated"] = "yes"
+	} else {
+		cm.Annotations["updated"] = "no"
+	}
+	return r.Client.Update(context.TODO(), cm)
+}

--- a/controllers/access_configmap_test.go
+++ b/controllers/access_configmap_test.go
@@ -1,0 +1,164 @@
+package controllers
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	hypersdsv1alpha1 "github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("syncAccessConfig", func() {
+	Context("1. with no configmap", func() {
+		r := createFakeCephClusterReconciler()
+		err := r.syncAccessConfig()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should create a configmap", func() {
+			cm := &corev1.ConfigMap{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: AccessConfigMapName}, cm)
+			Expect(err).Should(BeNil())
+		})
+		It("Should update state to Creating", func() {
+			cc := &hypersdsv1alpha1.CephCluster{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: r.Cluster.Name}, cc)
+			Expect(err).Should(BeNil())
+			Expect(cc.Status.State).Should(Equal(hypersdsv1alpha1.CephClusterStateCreating))
+		})
+		It("Should update readyToUse to false", func() {
+			cc := &hypersdsv1alpha1.CephCluster{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: r.Cluster.Name}, cc)
+			Expect(err).Should(BeNil())
+			cond := meta.FindStatusCondition(cc.Status.Conditions, hypersdsv1alpha1.ConditionReadyToUse)
+			Expect(cond).ShouldNot(BeNil())
+			Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
+		})
+	})
+
+	Context("2. with configmap", func() {
+		cm := newConfigMap(AccessConfigMapName)
+		r := createFakeCephClusterReconciler(cm)
+		err := r.syncAccessConfig()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should not delete the configmap", func() {
+			cm := &corev1.ConfigMap{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: AccessConfigMapName}, cm)
+			Expect(err).Should(BeNil())
+		})
+	})
+})
+
+var _ = Describe("isAccessConfigMapUpdated", func() {
+	Context("1. with no configmap", func() {
+		r := createFakeCephClusterReconciler()
+		_, found, err := r.isAccessConfigMapUpdated()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should return not found", func() {
+			Expect(found).Should(BeFalse())
+		})
+	})
+
+	Context("2. with configmap without annotation", func() {
+		cm := newConfigMap(AccessConfigMapName)
+		cm.Annotations = nil
+		r := createFakeCephClusterReconciler(cm)
+		_, _, err := r.isAccessConfigMapUpdated()
+
+		It("Should return error", func() {
+			Expect(err).ShouldNot(BeNil())
+		})
+	})
+
+	Context("3. with configmap with annotation(updated=no)", func() {
+		cm := newConfigMap(AccessConfigMapName)
+		cm.Annotations = map[string]string{
+			"updated": "no",
+		}
+		r := createFakeCephClusterReconciler(cm)
+		u, found, err := r.isAccessConfigMapUpdated()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should return updated false", func() {
+			Expect(u).Should(BeFalse())
+		})
+		It("Should return found configmap", func() {
+			Expect(found).Should(BeTrue())
+		})
+	})
+
+	Context("4. with configmap with annotation(updated=yes)", func() {
+		cm := newConfigMap(AccessConfigMapName)
+		cm.Annotations = map[string]string{
+			"updated": "yes",
+		}
+		r := createFakeCephClusterReconciler(cm)
+		u, found, err := r.isAccessConfigMapUpdated()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should return updated true", func() {
+			Expect(u).Should(BeTrue())
+		})
+		It("Should return found configmap", func() {
+			Expect(found).Should(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("updateAccessConfigMapAnnotation", func() {
+	Context("1. with no configmap", func() {
+		r := createFakeCephClusterReconciler()
+		err := r.updateAccessConfigMapAnnotation(true)
+
+		It("Should return not found error", func() {
+			Expect(errors.IsNotFound(err)).Should(BeTrue())
+		})
+	})
+
+	Context("2. with configmap and updated to no", func() {
+		cm := newConfigMap(AccessConfigMapName)
+		r := createFakeCephClusterReconciler(cm)
+		err := r.updateAccessConfigMapAnnotation(false)
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should configmap has annotation with updated no", func() {
+			cm := &corev1.ConfigMap{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: AccessConfigMapName}, cm)
+			Expect(err).Should(BeNil())
+			Expect(cm.Annotations["updated"]).Should(Equal("no"))
+		})
+	})
+
+	Context("3. with configmap and updated to yes", func() {
+		cm := newConfigMap(AccessConfigMapName)
+		r := createFakeCephClusterReconciler(cm)
+		err := r.updateAccessConfigMapAnnotation(true)
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should configmap has annotation with updated yes", func() {
+			cm := &corev1.ConfigMap{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: AccessConfigMapName}, cm)
+			Expect(err).Should(BeNil())
+			Expect(cm.Annotations["updated"]).Should(Equal("yes"))
+		})
+	})
+})

--- a/controllers/cephcluster_controller.go
+++ b/controllers/cephcluster_controller.go
@@ -18,11 +18,18 @@ package controllers
 
 import (
 	"context"
-
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hypersdsv1alpha1 "github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
 )
@@ -30,24 +37,86 @@ import (
 // CephClusterReconciler reconciles a CephCluster object
 type CephClusterReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log     logr.Logger
+	Scheme  *runtime.Scheme
+	Cluster *hypersdsv1alpha1.CephCluster
 }
 
 // +kubebuilder:rbac:groups=hypersds.tmax.io,resources=cephclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=hypersds.tmax.io,resources=cephclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=pods;configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 
+// Reconcile reads that state of the cluster for a CephCluster object and makes changes based on the state read
 func (r *CephClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("cephcluster", req.NamespacedName)
 
-	// your logic here
+	cachedCluster := &hypersdsv1alpha1.CephCluster{}
+	if err := r.Client.Get(context.TODO(), req.NamespacedName, cachedCluster); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+	r.Cluster = cachedCluster.DeepCopy()
+
+	syncAll := func() error {
+		if err := r.syncAccessConfig(); err != nil {
+			return err
+		}
+		if err := r.syncInstallConfig(); err != nil {
+			return err
+		}
+		if err := r.syncSecret(); err != nil {
+			return err
+		}
+		if err := r.syncRole(); err != nil {
+			return err
+		}
+		if err := r.syncRoleBinding(); err != nil {
+			return err
+		}
+		if err := r.syncProvisioner(); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := syncAll(); err != nil {
+		if err2 := r.updateStateWithReadyToUse(hypersdsv1alpha1.CephClusterStateError, metav1.ConditionFalse, "SeeMessages", err.Error()); err2 != nil {
+			return ctrl.Result{}, err2
+		}
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager creates a new CephCluster Controller and adds it to the Manager
 func (r *CephClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&hypersdsv1alpha1.CephCluster{}).
+		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
+			&handler.EnqueueRequestForOwner{IsController: true, OwnerType: &hypersdsv1alpha1.CephCluster{}}).
+		Watches(&source.Kind{Type: &corev1.Pod{}},
+			&handler.EnqueueRequestForOwner{IsController: true, OwnerType: &hypersdsv1alpha1.CephCluster{}}).
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			&handler.EnqueueRequestForOwner{IsController: true, OwnerType: &hypersdsv1alpha1.CephCluster{}}).
+		Watches(&source.Kind{Type: &v1.Role{}},
+			&handler.EnqueueRequestForOwner{IsController: true, OwnerType: &hypersdsv1alpha1.CephCluster{}}).
+		Watches(&source.Kind{Type: &v1.RoleBinding{}},
+			&handler.EnqueueRequestForOwner{IsController: true, OwnerType: &hypersdsv1alpha1.CephCluster{}}).
 		Complete(r)
+}
+
+func (r *CephClusterReconciler) updateStateWithReadyToUse(state hypersdsv1alpha1.CephClusterState, readyToUseStatus metav1.ConditionStatus,
+	reason, message string) error {
+	meta.SetStatusCondition(&r.Cluster.Status.Conditions, metav1.Condition{
+		Type:    hypersdsv1alpha1.ConditionReadyToUse,
+		Status:  readyToUseStatus,
+		Reason:  reason,
+		Message: message,
+	})
+	r.Cluster.Status.State = state
+	return r.Client.Status().Update(context.TODO(), r.Cluster)
 }

--- a/controllers/install_configmap.go
+++ b/controllers/install_configmap.go
@@ -1,0 +1,64 @@
+package controllers
+
+import (
+	"context"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (r *CephClusterReconciler) syncInstallConfig() error {
+	if _, err := r.getConfigMap(getConfigMapName(r.Cluster.Name)); err == nil {
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+
+	klog.Infof("syncInstallConfig: creating install config map %s", getConfigMapName(r.Cluster.Name))
+	cm, err := r.newConfigMap()
+	if err != nil {
+		return err
+	}
+	if err := r.Client.Create(context.TODO(), cm); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *CephClusterReconciler) getConfigMap(name string) (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: name}, cm); err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+func getConfigMapName(cephClusterName string) string {
+	return cephClusterName + "-install-config"
+}
+
+func (r *CephClusterReconciler) newConfigMap() (*corev1.ConfigMap, error) {
+	spec, err := yaml.Marshal(r.Cluster.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getConfigMapName(r.Cluster.Name),
+			Namespace: r.Cluster.Namespace,
+		},
+		Data: map[string]string{
+			"cluster.yaml": string(spec),
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(r.Cluster, cm, r.Scheme); err != nil {
+		return nil, err
+	}
+	return cm, nil
+}

--- a/controllers/install_configmap_test.go
+++ b/controllers/install_configmap_test.go
@@ -1,0 +1,40 @@
+package controllers
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("syncInstallConfig", func() {
+	Context("1. with no configmap", func() {
+		r := createFakeCephClusterReconciler()
+		err := r.syncInstallConfig()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should create a configmap", func() {
+			cm := &corev1.ConfigMap{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: getConfigMapName(r.Cluster.Name)}, cm)
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("2. with configmap", func() {
+		cm := newConfigMap(getConfigMapName(testCephClusterName))
+		r := createFakeCephClusterReconciler(cm)
+		err := r.syncInstallConfig()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should not delete the configmap", func() {
+			cm := &corev1.ConfigMap{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: getConfigMapName(r.Cluster.Name)}, cm)
+			Expect(err).Should(BeNil())
+		})
+	})
+})

--- a/controllers/provision_pod.go
+++ b/controllers/provision_pod.go
@@ -15,8 +15,7 @@ const (
 	// ProvisionContainerName indicates container name of the provision pod
 	ProvisionContainerName = "hypersds-provisioner"
 	// ProvisionContainerImage indicates image name of the provision pod
-	// TODO: ProvisionContainerImage should be updated
-	ProvisionContainerImage = "192.168.7.16:5000/hypersds-provisioner"
+	ProvisionContainerImage = "quay.io/tmaxanc/hypersds-provisioner:v0.1.0"
 	// ConfigMapVolumeName is used for creating configmap volume in pod specs
 	ConfigMapVolumeName = "ceph-cluster-info"
 	// ConfigMapVolumePath is a path where the configmap volume is mounted

--- a/controllers/provision_pod.go
+++ b/controllers/provision_pod.go
@@ -1,0 +1,130 @@
+package controllers
+
+import (
+	"context"
+	"github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// ProvisionContainerName indicates container name of the provision pod
+	ProvisionContainerName = "hypersds-provisioner"
+	// ProvisionContainerImage indicates image name of the provision pod
+	// TODO: ProvisionContainerImage should be updated
+	ProvisionContainerImage = "192.168.7.16:5000/hypersds-provisioner"
+	// ConfigMapVolumeName is used for creating configmap volume in pod specs
+	ConfigMapVolumeName = "ceph-cluster-info"
+	// ConfigMapVolumePath is a path where the configmap volume is mounted
+	ConfigMapVolumePath = "/manifest"
+)
+
+func (r *CephClusterReconciler) syncProvisioner() error {
+	if _, err := r.getConfigMap(getConfigMapName(r.Cluster.Name)); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	updated, foundCm, err := r.isAccessConfigMapUpdated()
+	if err != nil {
+		return err
+	} else if !foundCm {
+		return nil
+	}
+
+	if err = r.getSecret(); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	pod := &corev1.Pod{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: getProvisionPodName(r.Cluster.Name)}, pod)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	foundPod := err == nil
+
+	if !foundPod && !updated {
+		klog.Infof("syncProvisioner: creating new pod for ceph cluster %s", r.Cluster.Name)
+		newPod, err := r.newPod()
+		if err != nil {
+			return err
+		}
+		if err := r.Client.Create(context.TODO(), newPod); err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+	} else if foundPod && isPodCompleted(pod) && !updated {
+		klog.Infof("syncProvisioner: finishing for ceph cluster %s, deleting the pod and updating state", r.Cluster.Name)
+		if err := r.updateAccessConfigMapAnnotation(true); err != nil {
+			return err
+		}
+		if err := r.Client.Delete(context.TODO(), pod); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		if err := r.updateStateWithReadyToUse(v1alpha1.CephClusterStateCompleted, metav1.ConditionTrue, "CephClusterIsReady", "Ceph cluster is ready to use"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getProvisionPodName(cephClusterName string) string {
+	return cephClusterName + "-provision-pod"
+}
+
+func isPodCompleted(pod *corev1.Pod) bool {
+	return len(pod.Status.ContainerStatuses) != 0 &&
+		pod.Status.ContainerStatuses[0].State.Terminated != nil &&
+		pod.Status.ContainerStatuses[0].State.Terminated.Reason == "Completed"
+}
+
+func (r *CephClusterReconciler) newPod() (*corev1.Pod, error) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getProvisionPodName(r.Cluster.Name),
+			Namespace: r.Cluster.Namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  ProvisionContainerName,
+					Image: ProvisionContainerImage,
+					Env: []corev1.EnvVar{
+						{Name: "NAMESPACE", Value: r.Cluster.Namespace},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      ConfigMapVolumeName,
+							MountPath: ConfigMapVolumePath,
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: ConfigMapVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: getConfigMapName(r.Cluster.Name),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(r.Cluster, pod, r.Scheme); err != nil {
+		return nil, err
+	}
+	return pod, nil
+}

--- a/controllers/provision_pod_test.go
+++ b/controllers/provision_pod_test.go
@@ -1,0 +1,195 @@
+package controllers
+
+//	no.	config	accessConfig	secret	pod	updated	state
+//	1	x	x		x	x
+//	2	o	x		x	x
+//	3	o	o		x	x
+//	4	o	o		o	x	no
+//	5	o	o		o	x	yes
+//	6	o	o		o	o	no	Completed
+//	7	o	o		o	o	no	Running
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	hypersdsv1alpha1 "github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("syncProvisioner", func() {
+	Context("1. with no resource", func() {
+		r := createFakeCephClusterReconciler()
+		err := r.syncProvisioner()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("2. with configmap", func() {
+		cm := newConfigMap(getConfigMapName(testCephClusterName))
+		r := createFakeCephClusterReconciler(cm)
+		err := r.syncProvisioner()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("3. with configmap and access configmap", func() {
+		cm := newConfigMap(getConfigMapName(testCephClusterName))
+		accessCm := newConfigMap(AccessConfigMapName)
+		accessCm.Annotations = map[string]string{
+			"updated": "no",
+		}
+		r := createFakeCephClusterReconciler(cm, accessCm)
+		err := r.syncProvisioner()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("4. with configmap, access configmap and secret, updated=no", func() {
+		cm := newConfigMap(getConfigMapName(testCephClusterName))
+		accessCm := newConfigMap(AccessConfigMapName)
+		accessCm.Annotations = map[string]string{
+			"updated": "no",
+		}
+		s := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SecretName,
+				Namespace: testCephClusterNs,
+			},
+		}
+		r := createFakeCephClusterReconciler(cm, accessCm, s)
+		err := r.syncProvisioner()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should create a pod", func() {
+			pod := &corev1.Pod{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: getProvisionPodName(r.Cluster.Name)}, pod)
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("5. with configmap, access configmap and secret, updated=yes", func() {
+		cm := newConfigMap(getConfigMapName(testCephClusterName))
+		accessCm := newConfigMap(AccessConfigMapName)
+		accessCm.Annotations = map[string]string{
+			"updated": "yes",
+		}
+		s := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SecretName,
+				Namespace: testCephClusterNs,
+			},
+		}
+		r := createFakeCephClusterReconciler(cm, accessCm, s)
+		err := r.syncProvisioner()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("6. with configmap, access configmap, secret and pod(Completed), updated=no", func() {
+		cm := newConfigMap(getConfigMapName(testCephClusterName))
+		accessCm := newConfigMap(AccessConfigMapName)
+		accessCm.Annotations = map[string]string{
+			"updated": "no",
+		}
+		s := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SecretName,
+				Namespace: testCephClusterNs,
+			},
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      getProvisionPodName(testCephClusterName),
+				Namespace: testCephClusterNs,
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason: "Completed",
+							},
+						},
+					},
+				},
+			},
+		}
+		r := createFakeCephClusterReconciler(cm, accessCm, s, pod)
+		err := r.syncProvisioner()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should configmap has annotation with updated yes", func() {
+			cm := &corev1.ConfigMap{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: AccessConfigMapName}, cm)
+			Expect(err).Should(BeNil())
+			Expect(cm.Annotations["updated"]).Should(Equal("yes"))
+		})
+		It("Should delete the pod", func() {
+			pod := &corev1.Pod{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: getProvisionPodName(r.Cluster.Name)}, pod)
+			Expect(errors.IsNotFound(err)).Should(BeTrue())
+		})
+		It("Should update state to Completed", func() {
+			cc := &hypersdsv1alpha1.CephCluster{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: r.Cluster.Name}, cc)
+			Expect(err).Should(BeNil())
+			Expect(cc.Status.State).Should(Equal(hypersdsv1alpha1.CephClusterStateCompleted))
+		})
+		It("Should update readyToUse to true", func() {
+			cc := &hypersdsv1alpha1.CephCluster{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: r.Cluster.Name}, cc)
+			Expect(err).Should(BeNil())
+			cond := meta.FindStatusCondition(cc.Status.Conditions, hypersdsv1alpha1.ConditionReadyToUse)
+			Expect(cond).ShouldNot(BeNil())
+			Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	Context("7. with configmap, access configmap, secret and pod(Running), updated=no", func() {
+		cm := newConfigMap(getConfigMapName(testCephClusterName))
+		accessCm := newConfigMap(AccessConfigMapName)
+		accessCm.Annotations = map[string]string{
+			"updated": "no",
+		}
+		s := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SecretName,
+				Namespace: testCephClusterNs,
+			},
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      getProvisionPodName(testCephClusterName),
+				Namespace: testCephClusterNs,
+			},
+		}
+		r := createFakeCephClusterReconciler(cm, accessCm, s, pod)
+		err := r.syncProvisioner()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should not delete the pod", func() {
+			pod := &corev1.Pod{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: getProvisionPodName(r.Cluster.Name)}, pod)
+			Expect(err).Should(BeNil())
+		})
+	})
+})

--- a/controllers/role.go
+++ b/controllers/role.go
@@ -1,0 +1,58 @@
+package controllers
+
+import (
+	"context"
+	corev1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// RoleName indicates the name of the role for the provisioner pod
+const RoleName = "provisioner-role"
+
+func (r *CephClusterReconciler) syncRole() error {
+	if err := r.getRole(); err == nil {
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+
+	klog.Infof("syncRole: creating role %s", RoleName)
+	newRole, err := r.newRole()
+	if err != nil {
+		return err
+	}
+	if err := r.Client.Create(context.TODO(), newRole); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *CephClusterReconciler) getRole() error {
+	role := &corev1.Role{}
+	return r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: RoleName}, role)
+}
+
+func (r *CephClusterReconciler) newRole() (*corev1.Role, error) {
+	role := &corev1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleName,
+			Namespace: r.Cluster.Namespace,
+		},
+		Rules: []corev1.PolicyRule{
+			{
+				Verbs:     []string{"get", "list", "update", "patch"},
+				APIGroups: []string{""},
+				Resources: []string{"configmaps", "secrets"},
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(r.Cluster, role, r.Scheme); err != nil {
+		return nil, err
+	}
+	return role, nil
+}

--- a/controllers/role_test.go
+++ b/controllers/role_test.go
@@ -1,0 +1,46 @@
+package controllers
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("syncRole", func() {
+	Context("1. with no role", func() {
+		r := createFakeCephClusterReconciler()
+		err := r.syncRole()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should create a role", func() {
+			role := &corev1.Role{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: RoleName}, role)
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("2. with role", func() {
+		role := &corev1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RoleName,
+				Namespace: testCephClusterNs,
+			},
+		}
+		r := createFakeCephClusterReconciler(role)
+		err := r.syncRole()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should not delete the role", func() {
+			role := &corev1.Role{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: RoleName}, role)
+			Expect(err).Should(BeNil())
+		})
+	})
+})

--- a/controllers/rolebinding.go
+++ b/controllers/rolebinding.go
@@ -1,0 +1,66 @@
+package controllers
+
+import (
+	"context"
+	corev1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// RoleBindingName indicates the name of the rolebinding for the provisioner pod
+const RoleBindingName = "provisioner-rolebinding"
+
+func (r *CephClusterReconciler) syncRoleBinding() error {
+	if err := r.getRole(); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	rb := &corev1.RoleBinding{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: RoleBindingName}, rb); err == nil {
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+
+	klog.Infof("syncRoleBinding: creating rolebinding %s", RoleBindingName)
+	newRb, err := r.newRoleBinding()
+	if err != nil {
+		return err
+	}
+	if err := r.Client.Create(context.TODO(), newRb); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *CephClusterReconciler) newRoleBinding() (*corev1.RoleBinding, error) {
+	rb := &corev1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleBindingName,
+			Namespace: r.Cluster.Namespace,
+		},
+		Subjects: []corev1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "default",
+				Namespace: r.Cluster.Namespace,
+			},
+		},
+		RoleRef: corev1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     RoleName,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(r.Cluster, rb, r.Scheme); err != nil {
+		return nil, err
+	}
+	return rb, nil
+}

--- a/controllers/rolebinding_test.go
+++ b/controllers/rolebinding_test.go
@@ -1,0 +1,67 @@
+package controllers
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("syncRoleBinding", func() {
+	Context("1. with no role", func() {
+		r := createFakeCephClusterReconciler()
+		err := r.syncRoleBinding()
+
+		It("Should return no error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should not create a rolebinding", func() {
+			rb := &corev1.RoleBinding{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: RoleBindingName}, rb)
+			Expect(errors.IsNotFound(err)).Should(BeTrue())
+		})
+	})
+
+	Context("2. with role", func() {
+		role := &corev1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RoleName,
+				Namespace: testCephClusterNs,
+			},
+		}
+		r := createFakeCephClusterReconciler(role)
+		err := r.syncRoleBinding()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should create a rolebinding", func() {
+			rb := &corev1.RoleBinding{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: RoleBindingName}, rb)
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("3. with rolebinding", func() {
+		rb := &corev1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RoleBindingName,
+				Namespace: testCephClusterNs,
+			},
+		}
+		r := createFakeCephClusterReconciler(rb)
+		err := r.syncRoleBinding()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should not delete the rolebinding", func() {
+			rb := &corev1.RoleBinding{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: RoleBindingName}, rb)
+			Expect(err).Should(BeNil())
+		})
+	})
+})

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -1,0 +1,65 @@
+package controllers
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// SecretName indicates the name of the secret that contains admin keyring information
+const SecretName = "ceph-secret"
+
+func (r *CephClusterReconciler) syncSecret() error {
+	if err := r.getSecret(); err == nil {
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+
+	klog.Infof("syncSecret: creating secret %s", SecretName)
+	updated, found, err := r.isAccessConfigMapUpdated()
+	if err != nil {
+		return err
+	} else if !found {
+		return nil
+	}
+	if updated {
+		// This is the case when the secret is deleted after ceph cluster is completed.
+		if err2 := r.updateAccessConfigMapAnnotation(false); err2 != nil {
+			return err2
+		}
+	}
+
+	newSecret, err := r.newSecret()
+	if err != nil {
+		return err
+	}
+	if err := r.Client.Create(context.TODO(), newSecret); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (r *CephClusterReconciler) getSecret() error {
+	secret := &corev1.Secret{}
+	return r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: SecretName}, secret)
+}
+
+func (r *CephClusterReconciler) newSecret() (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SecretName,
+			Namespace: r.Cluster.Namespace,
+		},
+		Data: map[string][]byte{},
+	}
+
+	if err := controllerutil.SetControllerReference(r.Cluster, secret, r.Scheme); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}

--- a/controllers/secret_test.go
+++ b/controllers/secret_test.go
@@ -1,0 +1,74 @@
+package controllers
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("syncSecret", func() {
+	Context("1. with no secret, updated=no", func() {
+		cm := newConfigMap(AccessConfigMapName)
+		cm.Annotations = map[string]string{
+			"updated": "no",
+		}
+		r := createFakeCephClusterReconciler(cm)
+		err := r.syncSecret()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should create a secret", func() {
+			s := &corev1.Secret{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: SecretName}, s)
+			Expect(err).Should(BeNil())
+		})
+	})
+
+	Context("2. with no secret, updated=yes", func() {
+		cm := newConfigMap(AccessConfigMapName)
+		cm.Annotations = map[string]string{
+			"updated": "yes",
+		}
+		r := createFakeCephClusterReconciler(cm)
+		err := r.syncSecret()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should create a secret", func() {
+			s := &corev1.Secret{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: SecretName}, s)
+			Expect(err).Should(BeNil())
+		})
+		It("Should update configmap annotation(updated=no)", func() {
+			cm := &corev1.ConfigMap{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: AccessConfigMapName}, cm)
+			Expect(err).Should(BeNil())
+			Expect(cm.Annotations["updated"]).Should(Equal("no"))
+		})
+	})
+
+	Context("3. with secret", func() {
+		s := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SecretName,
+				Namespace: testCephClusterNs,
+			},
+		}
+		r := createFakeCephClusterReconciler(s)
+		err := r.syncSecret()
+
+		It("Should not return error", func() {
+			Expect(err).Should(BeNil())
+		})
+		It("Should not delete the secret", func() {
+			s := &corev1.Secret{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Cluster.Namespace, Name: SecretName}, s)
+			Expect(err).Should(BeNil())
+		})
+	})
+})

--- a/controllers/test_util.go
+++ b/controllers/test_util.go
@@ -1,0 +1,72 @@
+package controllers
+
+import (
+	hypersdsv1alpha1 "github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testCephClusterName = "testcc"
+	testCephClusterNs   = "default"
+)
+
+func createFakeCephClusterReconciler(objects ...runtime.Object) *CephClusterReconciler {
+	cc := newCephCluster()
+	c, s, err := createFakeClientAndScheme(append(objects, cc)...)
+	if err != nil {
+		panic(err)
+	}
+	return &CephClusterReconciler{Client: c, Scheme: s, Cluster: cc}
+}
+
+func newCephCluster() *hypersdsv1alpha1.CephCluster {
+	return &hypersdsv1alpha1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testCephClusterName,
+			Namespace: testCephClusterNs,
+		},
+		Spec: hypersdsv1alpha1.CephClusterSpec{
+			Mon: hypersdsv1alpha1.CephClusterMonSpec{
+				Count: 1,
+			},
+			Osd: []hypersdsv1alpha1.CephClusterOsdSpec{
+				{
+					HostName: "test",
+					Devices:  []string{"/dev/sda", "/dev/sdb"},
+				},
+			},
+			Nodes: []hypersdsv1alpha1.Node{
+				{
+					IP:       "0.0.0.0",
+					UserID:   "test",
+					Password: "test",
+					HostName: "test",
+				},
+			},
+		},
+	}
+}
+
+func createFakeClientAndScheme(objects ...runtime.Object) (client.Client, *runtime.Scheme, error) {
+	s := scheme.Scheme
+	if err := hypersdsv1alpha1.AddToScheme(s); err != nil {
+		return nil, nil, err
+	}
+	var objs []runtime.Object
+	objs = append(objs, objects...)
+	return fake.NewFakeClientWithScheme(s, objs...), s, nil
+}
+
+func newConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testCephClusterNs,
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,10 @@ require (
 	github.com/go-logr/zapr v0.2.0 // indirect
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
+	gopkg.in/yaml.v2 v2.3.0
+	k8s.io/api v0.19.4
 	k8s.io/apimachinery v0.19.4
 	k8s.io/client-go v0.19.4
+	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.6.4
 )

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+function usage {
+  echo " $0 [command]
+
+  Available Commands:
+    bootstrap
+  " >&2
+}
+
+function wait_condition {
+  cond=$1
+  status=${cond%%|*}
+  timeout=$2
+  interval=$3
+
+  for ((i=0; i<timeout; i+=$interval)) do
+    if eval $cond > /dev/null 2>&1; then echo "Conditon met"; return 0; fi;
+	    echo "Waiting $(((i+interval)/60)) minutes..."
+    sleep $interval
+    eval $status
+  done
+
+  echo "Timeout"
+  return 1
+}
+
+case "${1:-}" in
+  bootstrap)
+    echo "deploying ceph cluster cr ..."
+    kubectl apply -f config/samples/hypersds_v1alpha1_cephcluster.yaml
+    wait_condition "kubectl get cephclusters.hypersds.tmax.io | grep Completed" 1200 60
+    kubectl delete -f config/samples/hypersds_v1alpha1_cephcluster.yaml
+  ;;
+  *)
+    usage
+  ;;
+esac

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	metricsPort := 9443
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
@@ -57,7 +58,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		Port:               9443,
+		Port:               metricsPort,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "35b060ce.tmax.io",
 	})


### PR DESCRIPTION
- Implement controller of CephCluster CR
  - The CephCluster CR deploys a ceph cluster to users according to the spec.
    - It creates a `configmap` with the information defined in the spec. The CephCluster's spec requires node and ceph cluster information to deploy a ceph cluster.
    - Then, it creates a `pod` using the generated configmap. The pod deploys the ceph cluster.
    - It also creates `access configmap` and `secret` to store deployed ceph cluster information.
```
apiVersion: hypersds.tmax.io/v1alpha1
kind: CephCluster
metadata:
  name: cephcluster-sample
spec:
  mon:
    count: 1
  osd:
    - hostName: tmax
      devices:
        - /dev/sda
        - /dev/sdb
  nodes:
    - ip: 192.168.7.1
      userId: root
      password: "test"
      hostName: tmax
  config:
    "key": "value"
```

- e2e fix
  - change e2e test script
    - how: moved e2e test logic from the Makefile to a shell script
    - reason: Makefile define() is not perfect to perform complex logic
  - fix ubuntu vm snapshot
    - remove chronyd related packages
    - use ubuntu default systemd-timesyncd