### PR TITLE
Update go module name to url format

### DIFF
--- a/controllers/cephcluster_controller.go
+++ b/controllers/cephcluster_controller.go
@@ -24,7 +24,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	hypersdsv1alpha1 "hypersds-operator/api/v1alpha1"
+	hypersdsv1alpha1 "github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
 )
 
 // CephClusterReconciler reconciles a CephCluster object

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	hypersdsv1alpha1 "hypersds-operator/api/v1alpha1"
+	hypersdsv1alpha1 "github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module hypersds-operator
+module github.com/tmax-cloud/hypersds-operator
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	hypersdsv1alpha1 "hypersds-operator/api/v1alpha1"
-	"hypersds-operator/controllers"
+	hypersdsv1alpha1 "github.com/tmax-cloud/hypersds-operator/api/v1alpha1"
+	"github.com/tmax-cloud/hypersds-operator/controllers"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
Update the go module name to url format so that hypersds-operator can be imported from external project.