### PR TITLE
Prepare project merge with hypersds-provisioner

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -9,7 +9,7 @@ jobs:
         uses: hkusu/review-assign-action@v1
         with:
           assignees: ${{ github.actor }}
-          reviewers: hyoung-90, hbinkim
+          reviewers: hyoung-90, hbinkim, shellwedance, donggyupark
           max-num-of-reviewers: 2
           draft-keyword: wip
   size-label:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,27 +42,4 @@ jobs:
         run: make kubebuilder-download
       - name: build
         run: make docker-build
-  e2e:
-    needs: [image-build]
-    runs-on: self-hosted
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        config:
-        - {k8s: v1.19.8, runtime: crio, network: calico}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.13'
-      - run: | 
-          export KUBE_VERSION=${{ matrix.config.k8s }} KUBE_RUNTIME=${{ matrix.config.runtime }} KUBE_NETWORK=${{ matrix.config.network }}
-          ./hack/cluster.sh up
-          docker login -u=tmaxanc+robot -p=${{ secrets.QUAY_PASSWORD }} quay.io
-          make e2e
-  cleanup:
-    needs: [e2e]
-    runs-on: self-hosted
-    steps:
-      - run: ./hack/cluster.sh down
 

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ static-test: generate fmt vet manifests verify
 
 # Run unit test
 unit-test:
-	go test -v ./controllers/... -ginkgo.v -ginkgo.failFast
+	go test -v ./... -ginkgo.v -ginkgo.failFast
 
 # Minikube related command
 minikube-download:


### PR DESCRIPTION
- temporarily disable e2e phase from the ci/cd pipeline
- make go test to run throughout the entire project
- add hypersds-provisioner project contributors to code reviewers