### PR TITLE
Update docker registry info and prolinux repo info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= 192.168.7.16:5000/hypersds-operator:latest
+IMG ?= 192.168.9.22:5000/hypersds-operator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 # Name prefix to generate the names of all resources. This value must be the same as 'namePrefix' defined in config/default/kustomization.yaml


### PR DESCRIPTION
e2e test vm snapshot is updated to apply following changes

- registry ip address is updated
- prolinux repo info is updated
  - http://prolinux-repo.tmaxos.com/prolinux/8.2/os/x86_64/BaseOS
  - http://prolinux-repo.tmaxos.com/prolinux/8.2/os/x86_64/AppStream